### PR TITLE
Patch for double arrow insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "php-expressions-heper",
-	"displayName": "PHP expressions heper",
+	"name": "php-expressions-helper",
+	"displayName": "PHP expressions helper",
 	"description": "Helps you to write some expressions faster. Inspired by \"Netbeans PHP Enhancements plugin\"",
 	"version": "0.1.2",
 	"icon" : "elephant-6-128.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ export function activate(context: vscode.ExtensionContext) {
 					.trim()
 				const prevChar = prevText.slice(-1)
 
-				if (prevChar == '"' || prevChar == "'") {
+				if (/['"\w]/.test(prevChar)) {
 					const newPosition = new vscode.Position(line, character + 1)
 					const nextPosition = new vscode.Position(line, character + 2)
 					const nextText = doc.getText(


### PR DESCRIPTION
this case should be included
```
$key_var = 'some_key';
$array = [
    $key_var => 12345,
    CONSTANT_KEY => '123',
];
```
